### PR TITLE
MJ733 共有ボタンにアイコンを設定

### DIFF
--- a/LeftSidebarItem.html
+++ b/LeftSidebarItem.html
@@ -68,12 +68,13 @@
       <!-- App: Share-Link-->
         <article>
           <ul class="guide-list">
-            <li class="guide-list--item item__secondary">
+            <li class="guide-list--item item__primary">
               <button class="guide-list--item__btn" id="board-share-edit-method" style="font-weight: normal;">
-                <span>物と情報の同時編集方法</span>
+                <span class="miro-icon miro-icon-team" style="margin-right:10px;"></span>
+                <span>物情を同時編集</span>
               </button>
             </li>
-            <li class="guide-list--item item__secondary">
+            <li class="guide-list--item item__primary">
               <button class="guide-list--item__btn" id="board-reinstall-method" style="font-weight: normal;">
                 <span>アプリが動かない場合(再インストール)</span>
               </button>

--- a/css/Addstyle.css
+++ b/css/Addstyle.css
@@ -5,7 +5,7 @@
 .tab-ctrl {
   display: flex;
   flex-wrap: wrap;
-  padding: 14px 17px 0;
+  padding: 10px 17px 0;
 }
 
 .tab-ctrl .tab-ctrl-btn {
@@ -51,7 +51,6 @@
   visibility: hidden;
   opacity: 0;
   position: absolute;
-  top: 40px;
   left: 0;
   z-index: 1;
   width: 100%;
@@ -62,6 +61,11 @@
 .tab-content.show {
   visibility: visible;
   opacity: 1;
+}
+
+.tab-content article{
+  padding-top:10px;
+  padding-bottom:0px;
 }
 
 .question {
@@ -176,9 +180,9 @@
   padding-left: 12px;
 }
 
-/* .guide-list--item.item__primary {
-  margin-bottom: 16px;
-} */
+.guide-list .guide-list--item.item__primary {
+  margin-bottom: 10px;
+}
 
 
 .guide-list--book__btn {

--- a/css/LeftSidebarItem.css
+++ b/css/LeftSidebarItem.css
@@ -198,18 +198,12 @@ article > *:not(:first-child) {
 物の流れ線コネクトモード
 ***************************************************************** */
 
-#toggle-frame {
-  
-}
 #toggle-frame input {
   height: 0;
   width: 0;
   background: #c00;
 }
 
-#toggle-frame input::after {
-  
-}
 #mode-change-button {
   display: flex;
   width: 58px;
@@ -377,8 +371,6 @@ article > *:not(:first-child) {
   top: -6px;
   position: absolute;
 }
-#size-change .arrow .down {
-}
 #size-change .arrow .down::after {
   border-top-color: var(--color-default);
   top: 6px;
@@ -401,10 +393,30 @@ article > *:not(:first-child) {
 工程記号のみ選択
 ***************************************************************** */
 
-#select-only {
-  
-}
 #select-only button {
   height: 100%;
   width: 80px;
+}
+
+/* mirotone icon */
+.miro-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: default;
+  width: 24px;
+  height: 24px;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+  background-repeat: no-repeat;
+}
+
+.miro-icon-team {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M12 8a4 4 0 11-8 0 4 4 0 018 0zm5.5 6a3.5 3.5 0 100-7 3.5 3.5 0 000 7zm4.508 6.124a1 1 0 101.984-.248l-.171-1.372A4 4 0 0019.85 15h-4.04c.349.604.597 1.278.719 2h3.324a2 2 0 011.984 1.752l.172 1.372zm-7.994.04a1 1 0 001.973-.328l-.443-2.658A5 5 0 0010.612 13H5.389a5 5 0 00-4.932 4.178l-.443 2.658a1 1 0 101.973.328l.442-2.657A3 3 0 015.39 15h5.223a3 3 0 012.959 2.507l.443 2.657zM8 10a2 2 0 110-4 2 2 0 010 4zm8 .5a1.5 1.5 0 103 0 1.5 1.5 0 00-3 0z' fill='rgb(63,103,251)'/%3E%3C/svg%3E");
+}
+
+button .miro-icon{
+  cursor:pointer;
 }

--- a/sharedmethods.html
+++ b/sharedmethods.html
@@ -9,7 +9,7 @@
 
 <!-- ボード共有編集方法ポップアップ -->
 <body>
-    <header><b>物と情報の同時編集方法</b></header>
+    <header><b>物情を同時編集</b></header>
     <div class="content">
         <div class="message">メッセージをコピーして同時編集したいメンバーに送ってください</div>
         <div class=" box1">


### PR DESCRIPTION
下記の対応を実施しました。
①アイコンはMiro提供の物を利用 [Mirotone](https://www.mirotone.xyz/css/icons)
　＊ただmirotoneは一括導入すると既存レイアウトが乱れるため、個別で導入

②ボタンの文言変更「物情を同時編集」

③モーダルウィンドウ内のタイトル変更「物情を同時編集」
④共有とアンインストールボタンを強調に表示し、間隔を均等（10px）に調整
⑤空のCSS定義を削除（Visual Source Code上警告が出たため）